### PR TITLE
Make it work in Crystal 0.35.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
+dist: xenial
 language: crystal
+crystal:
+- latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    image: crystallang/crystal:0.29.0
+    image: crystallang/crystal:0.35.1
     working_dir: /app
     environment:
       EDA_ENV: ${MULTI_AUTH_ENV}

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 1.0.0
 authors:
   - Sergey Makridenkov <s@msa7.ru>
 
-crystal: 0.29.0
+crystal: 0.35.1
 
 license: MIT
 

--- a/src/multi_auth/providers/facebook.cr
+++ b/src/multi_auth/providers/facebook.cr
@@ -75,7 +75,8 @@ class MultiAuth::Provider::Facebook < MultiAuth::Provider
       key,
       secret,
       redirect_uri: redirect_uri,
-      token_uri: "/v2.9/oauth/access_token"
+      token_uri: "/v2.9/oauth/access_token",
+      auth_scheme: :request_body
     )
   end
 end

--- a/src/multi_auth/providers/facebook.cr
+++ b/src/multi_auth/providers/facebook.cr
@@ -29,20 +29,20 @@ class MultiAuth::Provider::Facebook < MultiAuth::Provider
   end
 
   private class FbUser
+    include JSON::Serializable
+
     property raw_json : String?
     property access_token : OAuth2::AccessToken?
     property picture_url : String?
 
-    JSON.mapping(
-      id: String,
-      name: String,
-      last_name: String?,
-      first_name: String?,
-      email: String?,
-      location: String?,
-      about: String?,
-      website: String?
-    )
+    property id : String
+    property name : String
+    property last_name : String?
+    property first_name : String?
+    property email : String?
+    property location : String?
+    property about : String?
+    property website : String?
   end
 
   private def fetch_fb_user(code)

--- a/src/multi_auth/providers/github.cr
+++ b/src/multi_auth/providers/github.cr
@@ -30,20 +30,22 @@ class MultiAuth::Provider::Github < MultiAuth::Provider
   end
 
   private class GhUser
+    include JSON::Serializable
+
     property raw_json : String?
     property access_token : OAuth2::AccessToken?
 
-    JSON.mapping(
-      id: {type: String, converter: String::RawConverter},
-      name: String,
-      email: String?,
-      login: String,
-      location: String?,
-      bio: String?,
-      avatar_url: String?,
-      blog: String?,
-      html_url: String?
-    )
+    @[JSON::Field(converter: String::RawConverter)]
+    property id : String
+
+    property name : String
+    property email : String?
+    property login : String
+    property location : String?
+    property bio : String?
+    property avatar_url : String?
+    property blog : String?
+    property html_url : String?
   end
 
   private def fetch_gh_user(code)

--- a/src/multi_auth/providers/github.cr
+++ b/src/multi_auth/providers/github.cr
@@ -65,7 +65,8 @@ class MultiAuth::Provider::Github < MultiAuth::Provider
       key,
       secret,
       authorize_uri: "/login/oauth/authorize",
-      token_uri: "/login/oauth/access_token"
+      token_uri: "/login/oauth/access_token",
+      auth_scheme: :request_body
     )
   end
 end

--- a/src/multi_auth/providers/google.cr
+++ b/src/multi_auth/providers/google.cr
@@ -27,7 +27,8 @@ class MultiAuth::Provider::Google < MultiAuth::Provider
       key,
       secret,
       token_uri: "/oauth2/v4/token",
-      redirect_uri: redirect_uri
+      redirect_uri: redirect_uri,
+      auth_scheme: :request_body
     )
 
     access_token = client.get_access_token_using_authorization_code(params["code"])

--- a/src/multi_auth/providers/twitter.cr
+++ b/src/multi_auth/providers/twitter.cr
@@ -28,19 +28,21 @@ class MultiAuth::Provider::Twitter < MultiAuth::Provider
   end
 
   private class TwUser
+    include JSON::Serializable
+
     property raw_json : String?
     property access_token : OAuth::AccessToken?
 
-    JSON.mapping(
-      id: {type: String, converter: String::RawConverter},
-      name: String,
-      screen_name: String,
-      location: String?,
-      description: String?,
-      url: String?,
-      profile_image_url: String?,
-      email: String?
-    )
+    @[JSON::Field(converter: String::RawConverter)]
+    property id : String
+    
+    property name : String
+    property screen_name : String
+    property location : String?
+    property description : String?
+    property url : String?
+    property profile_image_url : String?
+    property email : String?
   end
 
   private def fetch_tw_user(oauth_token, oauth_verifier)

--- a/src/multi_auth/providers/vk.cr
+++ b/src/multi_auth/providers/vk.cr
@@ -99,7 +99,8 @@ class MultiAuth::Provider::Vk < MultiAuth::Provider
       secret,
       redirect_uri: redirect_uri,
       authorize_uri: "/authorize",
-      token_uri: "/access_token"
+      token_uri: "/access_token",
+      auth_scheme: :request_body
     )
   end
 end

--- a/src/multi_auth/providers/vk.cr
+++ b/src/multi_auth/providers/vk.cr
@@ -36,12 +36,13 @@ class MultiAuth::Provider::Vk < MultiAuth::Provider
   end
 
   class VkTitle
-    JSON.mapping(
-      title: String
-    )
+    include JSON::Serializable
+    property title : String
   end
 
   class VkUser
+    include JSON::Serializable
+
     property raw_json : String?
     property access_token : OAuth2::AccessToken?
     property email : String?
@@ -51,25 +52,24 @@ class MultiAuth::Provider::Vk < MultiAuth::Provider
       "#{last_name} #{first_name}"
     end
 
-    JSON.mapping(
-      id: {type: String, converter: String::RawConverter},
-      last_name: String?,
-      first_name: String?,
-      site: String?,
-      city: VkTitle?,
-      country: VkTitle?,
-      domain: String?,
-      about: String?,
-      photo_max_orig: String?,
-      mobile_phone: String?,
-      home_phone: String?
-    )
+    @[JSON::Field(converter: String::RawConverter)]
+    property id : String
+
+    property last_name : String?
+    property first_name : String?
+    property site : String?
+    property city : VkTitle?
+    property country : VkTitle?
+    property domain : String?
+    property about : String?
+    property photo_max_orig : String?
+    property mobile_phone : String?
+    property home_phone : String?
   end
 
   class VkResponse
-    JSON.mapping(
-      response: Array(VkUser),
-    )
+    include JSON::Serializable
+    property response : Array(VkUser)
   end
 
   private def fetch_vk_user(code)


### PR DESCRIPTION
A few things new in Crystal 0.35 caused tests to fail in multi_auth and/or deprecation warnings. These were:

* basic_auth became a default schema for OAuth::Client, but multi_auth relies on passing auth params as request params. And I think at least in Github it's the only way to have it work.
* `JSON.mapping` was deprecated in favour of `JSON::Serializable`

Aside from this, I also made sure that Travis builds are run with the latest Crystal version and updated Docker configuration. 