### PR TITLE
Use regular webmock dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,5 +10,5 @@ license: MIT
 
 development_dependencies:
   webmock:
-    github: msa7/webmock.cr
-    branch: fix/before_request
+    github: manastech/webmock.cr
+    branch: master


### PR DESCRIPTION
This project used custom fix version of webmock, however it seems that it also works with regular one.